### PR TITLE
feat: Optimize API polling to only run when window is focused

### DIFF
--- a/packages/shared/src/hooks/__tests__/useWindowFocus.test.tsx
+++ b/packages/shared/src/hooks/__tests__/useWindowFocus.test.tsx
@@ -1,0 +1,77 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useWindowFocus } from '../useWindowFocus';
+
+describe('useWindowFocus', () => {
+  const originalHasFocus = document.hasFocus;
+  
+  beforeEach(() => {
+    document.hasFocus = vi.fn(() => true);
+  });
+
+  afterEach(() => {
+    document.hasFocus = originalHasFocus;
+    vi.clearAllMocks();
+  });
+
+  it('should return initial focus state based on document.hasFocus', () => {
+    document.hasFocus = vi.fn(() => false);
+    const { result } = renderHook(() => useWindowFocus());
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true when window is focused initially', () => {
+    document.hasFocus = vi.fn(() => true);
+    const { result } = renderHook(() => useWindowFocus());
+    expect(result.current).toBe(true);
+  });
+
+  it('should update focus state when window focus changes', () => {
+    const { result } = renderHook(() => useWindowFocus());
+    
+    // Initially focused
+    expect(result.current).toBe(true);
+
+    // Simulate window blur
+    act(() => {
+      window.dispatchEvent(new window.Event('blur'));
+    });
+    expect(result.current).toBe(false);
+
+    // Simulate window focus
+    act(() => {
+      window.dispatchEvent(new window.Event('focus'));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('should clean up event listeners on unmount', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderHook(() => useWindowFocus());
+    
+    unmount();
+    
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('focus', expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('blur', expect.any(Function));
+    
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('should handle multiple focus/blur events correctly', () => {
+    const { result } = renderHook(() => useWindowFocus());
+    
+    // Multiple blur events
+    act(() => {
+      window.dispatchEvent(new window.Event('blur'));
+      window.dispatchEvent(new window.Event('blur'));
+    });
+    expect(result.current).toBe(false);
+
+    // Multiple focus events
+    act(() => {
+      window.dispatchEvent(new window.Event('focus'));
+      window.dispatchEvent(new window.Event('focus'));
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -12,3 +12,4 @@ export * from './useRegistration';
 export * from './useRegistrationFormData';
 export * from './useHostGroups';
 export * from './useSmartProxies';
+export * from './useWindowFocus';

--- a/packages/shared/src/hooks/useNotifications.ts
+++ b/packages/shared/src/hooks/useNotifications.ts
@@ -3,12 +3,14 @@ import { useCallback } from 'react';
 import { notificationAPI } from '../api/notifications';
 import { useNotificationStore } from '../stores/notificationStore';
 import { useAuth } from '../auth/useAuth';
+import { useWindowFocus } from './useWindowFocus';
 
 const NOTIFICATIONS_QUERY_KEY = ['notifications'];
 const POLLING_INTERVAL = 30000; // 30 seconds
 
 export const useNotifications = () => {
   const { isAuthenticated } = useAuth();
+  const isWindowFocused = useWindowFocus();
   const {
     setNotifications,
     setLoading,
@@ -37,8 +39,8 @@ export const useNotifications = () => {
       }
     },
     enabled: isAuthenticated,
-    refetchInterval: POLLING_INTERVAL,
-    refetchIntervalInBackground: true,
+    refetchInterval: isWindowFocused ? POLLING_INTERVAL : false,
+    refetchIntervalInBackground: false,
     refetchOnWindowFocus: true,
     staleTime: 10000, // 10 seconds
   });

--- a/packages/shared/src/hooks/useWindowFocus.ts
+++ b/packages/shared/src/hooks/useWindowFocus.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Safely checks if the document currently has focus
+ * Handles SSR and environment compatibility
+ */
+const getInitialFocusState = (): boolean => {
+  try {
+    if (typeof document === 'undefined') {
+      return false;
+    }
+    
+    if (typeof document.hasFocus !== 'function') {
+      return false;
+    }
+    
+    return document.hasFocus();
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Hook to track window focus state
+ * Returns true when the window is focused, false when not focused
+ * 
+ * Uses document.hasFocus() for initial state (synchronous check) and 
+ * window focus/blur events for ongoing tracking (standard event pattern)
+ */
+export const useWindowFocus = (): boolean => {
+  const [isWindowFocused, setIsWindowFocused] = useState(() => getInitialFocusState());
+
+  useEffect(() => {
+    const handleFocus = () => setIsWindowFocused(true);
+    const handleBlur = () => setIsWindowFocused(false);
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('focus', handleFocus);
+      window.addEventListener('blur', handleBlur);
+    }
+
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('focus', handleFocus);
+        window.removeEventListener('blur', handleBlur);
+      }
+    };
+  }, []);
+
+  return isWindowFocused;
+};


### PR DESCRIPTION
## Summary
- Implements window focus detection to pause notification polling when user is not actively viewing the page
- Only notifications had active polling (30s interval), other APIs use staleTime caching only
- Maintains excellent UX by immediately refetching when user returns to tab

## Changes Made
- **New Hook**: `useWindowFocus()` - tracks window focus/blur events with proper cleanup
- **Updated Notifications**: Modified `useNotifications` to conditionally poll based on window focus
- **Comprehensive Tests**: Full test coverage for new functionality

## Performance Benefits
- ✅ **Reduced Server Load**: Eliminates unnecessary background API calls
- ✅ **Better Battery Life**: Less background activity on mobile devices
- ✅ **Improved Performance**: No polling overhead when tab is inactive
- ✅ **Zero UX Impact**: Still fetches fresh data immediately when user returns

## Technical Implementation
```typescript
// Only poll when window is focused
refetchInterval: isWindowFocused ? POLLING_INTERVAL : false,
refetchIntervalInBackground: false,
refetchOnWindowFocus: true, // Immediate refresh on return
```

## Test Plan
- [x] `yarn lint` - All linting checks pass
- [x] `yarn build` - TypeScript compilation successful  
- [x] `yarn test` - All tests pass including new window focus tests
- [x] Window focus/blur behavior works correctly
- [x] Polling pauses/resumes appropriately
- [x] Data freshness maintained on tab return

🤖 Generated with [Claude Code](https://claude.ai/code)