### PR TITLE
fix: correct container environment logging for Alpine Linux

### DIFF
--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -63,8 +63,7 @@ fi
 
 # Log environment information
 echo "=== Environment Information ==="
-echo "Container OS: $(cat /etc/fedora-release)"
-echo "Node.js version: $(node --version)"
+echo "Container OS: $(cat /etc/os-release 2>/dev/null | grep PRETTY_NAME | cut -d'"' -f2 || echo "Alpine Linux")"
 echo "Nginx version: $(nginx -v 2>&1)"
 echo "=== Container Ready ==="
 


### PR DESCRIPTION
## Problem
Container startup shows error messages:
```
cat: can't open '/etc/fedora-release': No such file or directory
Container OS: 
/container-entrypoint.sh: line 67: node: not found
Node.js version: 
```

## Root Cause
The entrypoint script was written for Fedora containers but we switched to Alpine Linux runtime.

## Solution
- **OS Detection**: Use `/etc/os-release` instead of `/etc/fedora-release`
- **Remove Node.js check**: Node.js isn't available in nginx:alpine runtime (only needed for builds)
- **Add fallback**: Gracefully handle missing OS info

## Expected Output
```
=== Environment Information ===
Container OS: Alpine Linux v3.22
Nginx version: nginx version: nginx/1.29.0
=== Container Ready ===
```

## Testing
The container functionality is unaffected - this only cleans up cosmetic startup logging errors.

🤖 Generated with [Claude Code](https://claude.ai/code)