### PR TITLE
feat: add Foreman favicon.svg to fix console 404 error

### DIFF
--- a/packages/user-portal/public/favicon.svg
+++ b/packages/user-portal/public/favicon.svg
@@ -1,0 +1,2538 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
+   inkscape:export-filename="/home/jimmac/Desktop/wi-fi.png"
+   width="255.41985"
+   height="194.27283"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="foreman.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0"
+   style="display:inline;enable-background:new">
+  <title
+     id="title8129">Foreman Icon</title>
+  <sodipodi:namedview
+     stroke="#ef2929"
+     fill="#f57900"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="0.25490196"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="-190.96507"
+     inkscape:cy="205.89723"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1276"
+     inkscape:window-height="690"
+     inkscape:window-x="0"
+     inkscape:window-y="748"
+     width="400px"
+     height="300px"
+     inkscape:snap-nodes="false"
+     inkscape:snap-bbox="true"
+     objecttolerance="7"
+     gridtolerance="12"
+     guidetolerance="13"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-page="true"
+     inkscape:object-nodes="false"
+     inkscape:window-maximized="0"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5883"
+       spacingx="1px"
+       spacingy="1px"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       snapvisiblegridlinesonly="true"
+       originx="-20.052918"
+       originy="-44.602769" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5742">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.33"
+         offset="0"
+         id="stop5744" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop5746" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5724">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop5726" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop5728" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5655">
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="0"
+         id="stop5657" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:0;"
+         offset="1"
+         id="stop5659" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5623">
+      <stop
+         style="stop-color:#efdd52;stop-opacity:1;"
+         offset="0"
+         id="stop5625" />
+      <stop
+         style="stop-color:#f2e26d;stop-opacity:0"
+         offset="1"
+         id="stop5627" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3453"
+       id="linearGradient3499"
+       gradientUnits="userSpaceOnUse"
+       x1="582.04169"
+       y1="1102.4139"
+       x2="582.04169"
+       y2="1023.9925" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3453">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3455" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3457" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3453"
+       id="linearGradient3459-7"
+       x1="582.04169"
+       y1="1102.4139"
+       x2="582.04169"
+       y2="1023.9925"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12863"
+       id="radialGradient6341"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1388493,0,0,1.200468,-77.200227,-214.605)"
+       cx="556"
+       cy="1063.7086"
+       fx="556"
+       fy="1063.7086"
+       r="44" />
+    <linearGradient
+       id="linearGradient12863">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop12865" />
+      <stop
+         id="stop12871"
+         offset="0.62350565"
+         style="stop-color:#888a85;stop-opacity:1" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="0.8054316"
+         id="stop12873" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop12867" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12897"
+       id="radialGradient6343"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8604586,0,0,1.8604586,-459.48492,-891.43519)"
+       cx="540.88086"
+       cy="1031.9064"
+       fx="540.88086"
+       fy="1031.9064"
+       r="44" />
+    <linearGradient
+       id="linearGradient12897">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop12899" />
+      <stop
+         id="stop3397"
+         offset="0.23620702"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop12901" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3427"
+       id="linearGradient6345"
+       gradientUnits="userSpaceOnUse"
+       x1="559.20093"
+       y1="1119.4701"
+       x2="518.88013"
+       y2="968.99078" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3427">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3429" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3431" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12911"
+       id="radialGradient6347"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6153888,0,0,1.4833302,-909.47024,-534.8944)"
+       cx="562.80469"
+       cy="1106.6852"
+       fx="562.80469"
+       fy="1106.6852"
+       r="44.595737" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient12911">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop12913" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="1"
+         id="stop12915" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3580"
+       id="linearGradient6349"
+       gradientUnits="userSpaceOnUse"
+       x1="534.77368"
+       y1="1093.9681"
+       x2="576.95667"
+       y2="1020.9051" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3580">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3582" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3584" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530"
+       id="linearGradient6351"
+       gradientUnits="userSpaceOnUse"
+       x1="143.99997"
+       y1="106.25386"
+       x2="143.99997"
+       y2="91.980705" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5530">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop5532" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1"
+         id="stop5534" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530"
+       id="linearGradient6353"
+       gradientUnits="userSpaceOnUse"
+       x1="143.77536"
+       y1="235.92043"
+       x2="143.77536"
+       y2="221.91942" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530"
+       id="linearGradient6355"
+       gradientUnits="userSpaceOnUse"
+       x1="211.0293"
+       y1="170.50592"
+       x2="211.0293"
+       y2="157.49393" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530"
+       id="linearGradient6357"
+       gradientUnits="userSpaceOnUse"
+       x1="77.136726"
+       y1="170.73593"
+       x2="77.136726"
+       y2="157.23462" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3401"
+       id="radialGradient3407"
+       cx="556"
+       cy="1068"
+       fx="556"
+       fy="1068"
+       r="44"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3401">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3403" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3405" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4428-9"
+       id="linearGradient4192-9"
+       gradientUnits="userSpaceOnUse"
+       x1="-106.75165"
+       y1="174.02757"
+       x2="-85.375572"
+       y2="156.63098" />
+    <linearGradient
+       id="linearGradient4428-9"
+       inkscape:collect="always">
+      <stop
+         id="stop4430"
+         offset="0"
+         style="stop-color:#2e3436;stop-opacity:1" />
+      <stop
+         id="stop4432"
+         offset="1"
+         style="stop-color:#888a85;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4796"
+       id="linearGradient4194-0"
+       gradientUnits="userSpaceOnUse"
+       x1="-100"
+       y1="167.71313"
+       x2="-100"
+       y2="157.19179" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4796">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop4798" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="1"
+         id="stop4800" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3888-1"
+       id="linearGradient4184-8"
+       gradientUnits="userSpaceOnUse"
+       x1="96.625"
+       y1="166"
+       x2="96.625"
+       y2="162.12299" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3888-1">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="0"
+         id="stop3890" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3892" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5356"
+       id="linearGradient4180-3"
+       gradientUnits="userSpaceOnUse"
+       x1="118.68687"
+       y1="179.42181"
+       x2="77.832031"
+       y2="155.83426" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5356">
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="0"
+         id="stop5358" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="1"
+         id="stop5360" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4936"
+       id="linearGradient4182-1"
+       gradientUnits="userSpaceOnUse"
+       x1="110"
+       y1="167.80295"
+       x2="110"
+       y2="154.34483" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4936">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop4938" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="1"
+         id="stop4940" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3541-1"
+       id="radialGradient2689"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3773467,-1.791245e-7,1.7912446e-7,1.3773464,-207.83681,-395.55015)"
+       cx="549.57959"
+       cy="1053.6022"
+       fx="549.57959"
+       fy="1053.6022"
+       r="44" />
+    <linearGradient
+       id="linearGradient3541-1">
+      <stop
+         id="stop3543-0"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0.30514973"
+         id="stop5354" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="0.63298833"
+         id="stop5352" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0.85721445"
+         id="stop3545-3" />
+      <stop
+         id="stop3547"
+         offset="1"
+         style="stop-color:#2e3436;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13249"
+       id="radialGradient4096"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9936278,0,0,0.3495627,3.5429153,708.68473)"
+       cx="556"
+       cy="1115.3873"
+       fx="556"
+       fy="1115.3873"
+       r="44" />
+    <linearGradient
+       id="linearGradient13249">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop13251" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop13253" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13238"
+       id="radialGradient4098"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7739069,0,0,0.71408231,-965.50038,297.44046)"
+       cx="543.42859"
+       cy="1035"
+       fx="543.42859"
+       fy="1035"
+       r="44" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13238">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop13240" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop13243" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13249-6-3"
+       id="radialGradient6295-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9936278,0,0,0.3495627,3.5429153,708.68473)"
+       cx="556"
+       cy="1115.3873"
+       fx="556"
+       fy="1115.3873"
+       r="44" />
+    <linearGradient
+       id="linearGradient13249-6-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop13251-6-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop13253-9-5" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4254-7"
+       id="radialGradient6297-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5434298,0,0,1.553224,-832.13128,-571.17705)"
+       cx="539.14423"
+       cy="1032.4518"
+       fx="539.14423"
+       fy="1032.4518"
+       r="44" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4254-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4256-17" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4258-0" />
+    </linearGradient>
+    <radialGradient
+       r="44"
+       fy="1053.6022"
+       fx="549.57959"
+       cy="1053.6022"
+       cx="549.57959"
+       gradientTransform="matrix(1.3773467,-1.791245e-7,1.7912446e-7,1.3773464,-207.83681,-395.55015)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6576-6"
+       xlink:href="#linearGradient3541-12-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3541-12-0">
+      <stop
+         id="stop3543-20-4"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0.30514973"
+         id="stop5354-2-1" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="0.63298833"
+         id="stop5352-17-3" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0.85721445"
+         id="stop3545-51-0" />
+      <stop
+         id="stop3547-7-2"
+         offset="1"
+         style="stop-color:#2e3436;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4264-7-7-4-6"
+       id="linearGradient6869-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-546.0521,-100.39952)"
+       x1="720.7771"
+       y1="374.90027"
+       x2="717.61865"
+       y2="363.11279" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4264-7-7-4-6">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4266-78-1-3-0" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="1"
+         id="stop4268-2-9-7-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4264-8-1-0-9-5"
+       id="linearGradient6872-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.64285714,-645.99943,-563.64286)"
+       x1="720.7771"
+       y1="374.90027"
+       x2="717.61865"
+       y2="363.11279" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4264-8-1-0-9-5">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4266-7-9-5-9-4" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="1"
+         id="stop4268-3-7-7-3-3" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13249-6-15-4"
+       id="radialGradient6841-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9936278,0,0,0.3495627,3.5429153,708.68473)"
+       cx="556"
+       cy="1115.3873"
+       fx="556"
+       fy="1115.3873"
+       r="44" />
+    <linearGradient
+       id="linearGradient13249-6-15-4">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop13251-6-6-3" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop13253-9-7-1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4254-3-1"
+       id="radialGradient6843-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5434298,0,0,1.553224,-832.13128,-571.17705)"
+       cx="539.14423"
+       cy="1032.4518"
+       fx="539.14423"
+       fy="1032.4518"
+       r="44" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4254-3-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4256-5-0" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4258-5-9" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3541-9-5"
+       id="radialGradient6845-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3773467,-1.791245e-7,1.7912446e-7,1.3773464,-207.83681,-395.55015)"
+       cx="549.57959"
+       cy="1053.6022"
+       fx="549.57959"
+       fy="1053.6022"
+       r="44" />
+    <linearGradient
+       id="linearGradient3541-9-5">
+      <stop
+         id="stop3543-2-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0.30514973"
+         id="stop5354-0-2" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="0.63298833"
+         id="stop5352-1-5" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0.85721445"
+         id="stop3545-2-9" />
+      <stop
+         id="stop3547-5-1"
+         offset="1"
+         style="stop-color:#2e3436;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4264-4-7"
+       id="linearGradient6794-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.64285714,-594.13498,81.626262)"
+       x1="720.7771"
+       y1="374.90027"
+       x2="717.61865"
+       y2="363.11279" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4264-4-7">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4266-75-4" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="1"
+         id="stop4268-7-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4264-8-4-9"
+       id="linearGradient6798-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.35714286,-579,-455.35714)"
+       x1="720.7771"
+       y1="374.90027"
+       x2="717.61865"
+       y2="363.11279" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4264-8-4-9">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4266-7-6-1" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="1"
+         id="stop4268-3-4-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3580-1-7"
+       id="linearGradient6847-8"
+       gradientUnits="userSpaceOnUse"
+       x1="534.77368"
+       y1="1093.9681"
+       x2="576.95667"
+       y2="1020.9051" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3580-1-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3582-4-4" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3584-4-9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-80-1"
+       id="linearGradient6849-3"
+       gradientUnits="userSpaceOnUse"
+       x1="143.99997"
+       y1="106.25386"
+       x2="143.99997"
+       y2="91.980705" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5530-80-1">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop5532-8-3" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1"
+         id="stop5534-7-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-80-1"
+       id="linearGradient6851-7"
+       gradientUnits="userSpaceOnUse"
+       x1="143.77536"
+       y1="235.92043"
+       x2="143.77536"
+       y2="221.91942" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-80-1"
+       id="linearGradient6853-9"
+       gradientUnits="userSpaceOnUse"
+       x1="211.0293"
+       y1="170.50592"
+       x2="211.0293"
+       y2="157.49393" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-80-1"
+       id="linearGradient6855-3"
+       gradientUnits="userSpaceOnUse"
+       x1="77.136726"
+       y1="170.73593"
+       x2="77.136726"
+       y2="157.23462" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12863-9-0"
+       id="radialGradient6857-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1388493,0,0,1.200468,-77.200227,-214.605)"
+       cx="556"
+       cy="1063.7086"
+       fx="556"
+       fy="1063.7086"
+       r="44" />
+    <linearGradient
+       id="linearGradient12863-9-0">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop12865-7-0" />
+      <stop
+         id="stop12871-0-8"
+         offset="0.62350565"
+         style="stop-color:#888a85;stop-opacity:1" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="0.8054316"
+         id="stop12873-3-6" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop12867-2-8" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12897-9-3"
+       id="radialGradient6859-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8604586,0,0,1.8604586,-459.48492,-891.43519)"
+       cx="540.88086"
+       cy="1031.9064"
+       fx="540.88086"
+       fy="1031.9064"
+       r="44" />
+    <linearGradient
+       id="linearGradient12897-9-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop12899-9-8" />
+      <stop
+         id="stop3397-1-5"
+         offset="0.23620702"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop12901-1-0" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4244-6-0-6"
+       id="radialGradient6861-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7727271,0,0,1.7727271,-417.97349,-794.04003)"
+       cx="540.90698"
+       cy="1027.5814"
+       fx="540.90698"
+       fy="1027.5814"
+       r="45.023254" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4244-6-0-6">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop4246-6-0-8" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1"
+         id="stop4248-9-4-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3453-8"
+       id="linearGradient6863-2"
+       gradientUnits="userSpaceOnUse"
+       x1="582.04169"
+       y1="1102.4139"
+       x2="582.04169"
+       y2="1023.9925" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3453-8">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3455-3" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3457-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3453-8"
+       id="linearGradient6865-7"
+       gradientUnits="userSpaceOnUse"
+       x1="582.04169"
+       y1="1102.4139"
+       x2="582.04169"
+       y2="1023.9925" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5594-6"
+       id="radialGradient4322-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5625783,0,0,1.5625783,-311.96843,-582.68109)"
+       cx="554.53333"
+       cy="1035.7333"
+       fx="554.53333"
+       fy="1035.7333"
+       r="46.933334" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5594-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop5596-6" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop5598-2" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4244-9-2-0-1-7"
+       id="radialGradient4324-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7727271,0,0,1.7727271,-417.97349,-794.04003)"
+       cx="540.90698"
+       cy="1027.5814"
+       fx="540.90698"
+       fy="1027.5814"
+       r="45.023254" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4244-9-2-0-1-7">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop4246-9-9-9-2-0" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1"
+         id="stop4248-8-5-8-2-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3580-71-2-2"
+       id="linearGradient4318-7"
+       gradientUnits="userSpaceOnUse"
+       x1="534.77368"
+       y1="1093.9681"
+       x2="576.95667"
+       y2="1020.9051" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3580-71-2-2">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3582-0-8-3" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3584-1-5-5" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13249-6-1-3-6-7"
+       id="radialGradient5370-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9936278,0,0,0.3495627,3.5429153,708.68473)"
+       cx="556"
+       cy="1115.3873"
+       fx="556"
+       fy="1115.3873"
+       r="44" />
+    <linearGradient
+       id="linearGradient13249-6-1-3-6-7">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop13251-6-8-4-09-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop13253-9-3-6-7-9" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13249-6-1-1"
+       id="radialGradient6931-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9936278,0,0,0.3495627,3.5429153,708.68473)"
+       cx="556"
+       cy="1115.3873"
+       fx="556"
+       fy="1115.3873"
+       r="44" />
+    <linearGradient
+       id="linearGradient13249-6-1-1">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop13251-6-8-6" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop13253-9-3-4" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4254-6-5"
+       id="radialGradient6933-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5434298,0,0,1.553224,-832.13128,-571.17705)"
+       cx="539.14423"
+       cy="1032.4518"
+       fx="539.14423"
+       fy="1032.4518"
+       r="44" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4254-6-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4256-1-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4258-9-8" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4244-9-2-0-3"
+       id="radialGradient4410-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7727271,0,0,1.7727271,-417.97349,-794.04003)"
+       cx="540.90698"
+       cy="1027.5814"
+       fx="540.90698"
+       fy="1027.5814"
+       r="45.023254" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4244-9-2-0-3">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop4246-9-9-9-3" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1"
+         id="stop4248-8-5-8-5" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12863-8-5"
+       id="radialGradient4412-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1388493,0,0,1.200468,-77.200227,-214.605)"
+       cx="556"
+       cy="1063.7086"
+       fx="556"
+       fy="1063.7086"
+       r="44" />
+    <linearGradient
+       id="linearGradient12863-8-5">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop12865-4-7" />
+      <stop
+         id="stop12871-5-0"
+         offset="0.62350565"
+         style="stop-color:#888a85;stop-opacity:1" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="0.8054316"
+         id="stop12873-5-7" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop12867-20-8" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12897-68-9"
+       id="radialGradient4414-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8604586,0,0,1.8604586,-459.48492,-891.43519)"
+       cx="540.88086"
+       cy="1031.9064"
+       fx="540.88086"
+       fy="1031.9064"
+       r="44" />
+    <linearGradient
+       id="linearGradient12897-68-9">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop12899-0-3" />
+      <stop
+         id="stop3397-26-9"
+         offset="0.23620702"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop12901-6-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3580-71-5"
+       id="linearGradient4416-5"
+       gradientUnits="userSpaceOnUse"
+       x1="534.77368"
+       y1="1093.9681"
+       x2="576.95667"
+       y2="1020.9051" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3580-71-5">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3582-0-5" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3584-1-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-8-6"
+       id="linearGradient4418-0"
+       gradientUnits="userSpaceOnUse"
+       x1="143.99997"
+       y1="106.25386"
+       x2="143.99997"
+       y2="91.980705" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5530-8-6">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop5532-1-2" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1"
+         id="stop5534-1-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-8-6"
+       id="linearGradient4420-9-9"
+       gradientUnits="userSpaceOnUse"
+       x1="143.77536"
+       y1="235.92043"
+       x2="143.77536"
+       y2="221.91942" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-8-6"
+       id="linearGradient4422-3-9"
+       gradientUnits="userSpaceOnUse"
+       x1="211.0293"
+       y1="170.50592"
+       x2="211.0293"
+       y2="157.49393" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-8-6"
+       id="linearGradient4424-3-2"
+       gradientUnits="userSpaceOnUse"
+       x1="77.136726"
+       y1="170.73593"
+       x2="77.136726"
+       y2="157.23462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3453-8"
+       id="linearGradient4432-9-9"
+       gradientUnits="userSpaceOnUse"
+       x1="582.04169"
+       y1="1102.4139"
+       x2="582.04169"
+       y2="1023.9925" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3453-8"
+       id="linearGradient4434-6-6"
+       gradientUnits="userSpaceOnUse"
+       x1="582.04169"
+       y1="1102.4139"
+       x2="582.04169"
+       y2="1023.9925" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4244-6-5"
+       id="radialGradient5610-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7727271,0,0,1.7727271,-417.97349,-794.04003)"
+       cx="540.90698"
+       cy="1027.5814"
+       fx="540.90698"
+       fy="1027.5814"
+       r="45.023254" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4244-6-5">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop4246-6-3" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1"
+         id="stop4248-9-8" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12863-6"
+       id="radialGradient5612-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1388493,0,0,1.200468,-77.200227,-214.605)"
+       cx="556"
+       cy="1063.7086"
+       fx="556"
+       fy="1063.7086"
+       r="44" />
+    <linearGradient
+       id="linearGradient12863-6">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop12865-0" />
+      <stop
+         id="stop12871-2"
+         offset="0.62350565"
+         style="stop-color:#888a85;stop-opacity:1" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="0.8054316"
+         id="stop12873-6" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop12867-9" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient12897-0"
+       id="radialGradient5614-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8604586,0,0,1.8604586,-459.48492,-891.43519)"
+       cx="540.88086"
+       cy="1031.9064"
+       fx="540.88086"
+       fy="1031.9064"
+       r="44" />
+    <linearGradient
+       id="linearGradient12897-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop12899-8" />
+      <stop
+         id="stop3397-7"
+         offset="0.23620702"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop12901-65" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3580-0"
+       id="linearGradient5616-0"
+       gradientUnits="userSpaceOnUse"
+       x1="534.77368"
+       y1="1093.9681"
+       x2="576.95667"
+       y2="1020.9051" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3580-0">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3582-6" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3584-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-4"
+       id="linearGradient6781-5"
+       gradientUnits="userSpaceOnUse"
+       x1="143.99997"
+       y1="106.25386"
+       x2="143.99997"
+       y2="91.980705" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient5530-4">
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="0"
+         id="stop5532-9" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1"
+         id="stop5534-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-4"
+       id="linearGradient6783-6"
+       gradientUnits="userSpaceOnUse"
+       x1="143.77536"
+       y1="235.92043"
+       x2="143.77536"
+       y2="221.91942" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-4"
+       id="linearGradient6785-8"
+       gradientUnits="userSpaceOnUse"
+       x1="211.0293"
+       y1="170.50592"
+       x2="211.0293"
+       y2="157.49393" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5530-4"
+       id="linearGradient6787-3"
+       gradientUnits="userSpaceOnUse"
+       x1="77.136726"
+       y1="170.73593"
+       x2="77.136726"
+       y2="157.23462" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4849-8-4-3"
+       id="linearGradient5626-2"
+       gradientUnits="userSpaceOnUse"
+       x1="556"
+       y1="1111.3027"
+       x2="552.65161"
+       y2="1085.869" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4849-8-4-3">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop4851-7-8-6" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop4853-4-4-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3453-8"
+       id="linearGradient5606-7"
+       gradientUnits="userSpaceOnUse"
+       x1="582.04169"
+       y1="1102.4139"
+       x2="582.04169"
+       y2="1023.9925" />
+    <linearGradient
+       y2="1023.9925"
+       x2="582.04169"
+       y1="1102.4139"
+       x1="582.04169"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7629"
+       xlink:href="#linearGradient3453-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient6391"
+       inkscape:collect="always">
+      <stop
+         id="stop6393"
+         offset="0"
+         style="stop-color:#f2da06;stop-opacity:1;" />
+      <stop
+         style="stop-color:#fcee72;stop-opacity:1"
+         offset="0.44511068"
+         id="stop6403" />
+      <stop
+         id="stop6395"
+         offset="1"
+         style="stop-color:#f2da06;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6358"
+       inkscape:collect="always">
+      <stop
+         id="stop6360"
+         offset="0"
+         style="stop-color:#e9d012;stop-opacity:1" />
+      <stop
+         style="stop-color:#efd840;stop-opacity:1"
+         offset="0.46028548"
+         id="stop6366" />
+      <stop
+         id="stop6368"
+         offset="0.76600951"
+         style="stop-color:#d2b828;stop-opacity:1;" />
+      <stop
+         id="stop6362"
+         offset="1"
+         style="stop-color:#eacf4e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6757"
+       inkscape:collect="always">
+      <stop
+         id="stop6760"
+         offset="0"
+         style="stop-color:#ddbe0c;stop-opacity:1;" />
+      <stop
+         id="stop6762"
+         offset="1"
+         style="stop-color:#ddbe0c;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6735"
+       inkscape:collect="always">
+      <stop
+         id="stop6737"
+         offset="0"
+         style="stop-color:#f5e789;stop-opacity:1" />
+      <stop
+         id="stop6739"
+         offset="1"
+         style="stop-color:#eed73f;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6383"
+       inkscape:collect="always">
+      <stop
+         id="stop6385"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop6387"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6409"
+       inkscape:collect="always">
+      <stop
+         id="stop6411"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop6413"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6349-8"
+       inkscape:collect="always">
+      <stop
+         id="stop6351"
+         offset="0"
+         style="stop-color:#ddbe0c;stop-opacity:1;" />
+      <stop
+         id="stop6353"
+         offset="1"
+         style="stop-color:#ddbe0c;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6371"
+       inkscape:collect="always">
+      <stop
+         id="stop6373"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop6375"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6689"
+       inkscape:collect="always">
+      <stop
+         id="stop6691"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop6693"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6474"
+       inkscape:collect="always">
+      <stop
+         id="stop6476"
+         offset="0"
+         style="stop-color:#edd60c;stop-opacity:1;" />
+      <stop
+         id="stop6478"
+         offset="1"
+         style="stop-color:#ad9c08;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6745"
+       inkscape:collect="always">
+      <stop
+         id="stop6747"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop6749"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6441"
+       inkscape:collect="always">
+      <stop
+         id="stop6443"
+         offset="0"
+         style="stop-color:#f5e683;stop-opacity:1" />
+      <stop
+         id="stop6445"
+         offset="1"
+         style="stop-color:#eed73f;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6415"
+       inkscape:collect="always">
+      <stop
+         id="stop6417"
+         offset="0"
+         style="stop-color:#f9f1b8;stop-opacity:1;" />
+      <stop
+         id="stop6419"
+         offset="1"
+         style="stop-color:#f9f1b8;stop-opacity:0;" />
+    </linearGradient>
+    <filter
+       height="1.0887192"
+       y="-0.044359654"
+       width="1.3903067"
+       x="-0.19515337"
+       id="filter6435"
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         id="feGaussianBlur6437"
+         stdDeviation="0.69678049"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6391"
+       id="linearGradient14340"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9476162,0.01088823,0.2330856,0.951552,42.802948,-12.140683)"
+       x1="162.0209"
+       y1="-141.84306"
+       x2="228.07239"
+       y2="-112.76989" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6358"
+       id="radialGradient14342"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3058823,0.02352941,-0.01765849,0.9800465,-67.740896,0.6035973)"
+       cx="211.5"
+       cy="-172.53897"
+       fx="211.5"
+       fy="-172.53897"
+       r="42.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6358"
+       id="radialGradient14344"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3058823,0.02352941,-0.01765849,0.9800465,-67.555646,0.6452304)"
+       cx="211.5"
+       cy="-172.53897"
+       fx="211.5"
+       fy="-172.53897"
+       r="42.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6757"
+       id="radialGradient14346"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2969093,-0.04698277,0.05811624,3.1475662,-252.60951,335.98737)"
+       cx="201.52219"
+       cy="-150.49968"
+       fx="201.52219"
+       fy="-150.49968"
+       r="17.65089" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6735"
+       id="radialGradient14348"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4196282,-0.02338442,0.07591614,2.7479938,-71.118147,263.97799)"
+       cx="195.68195"
+       cy="-149.60544"
+       fx="195.68195"
+       fy="-149.60544"
+       r="8.5016947" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6383"
+       id="radialGradient14350"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1212121,0,0,0.6529147,-27.636364,-63.387204)"
+       cx="226.67188"
+       cy="-153.96692"
+       fx="226.67188"
+       fy="-153.96692"
+       r="11.671875" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6409"
+       id="radialGradient14352"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.3996216,0,-80.958813)"
+       cx="181.81541"
+       cy="-85.738495"
+       fx="181.81541"
+       fy="-85.738495"
+       r="49.107819" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6349-8"
+       id="radialGradient14354"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.347594,0,58.403355)"
+       cx="194.55148"
+       cy="-168.02176"
+       fx="194.55148"
+       fy="-168.02176"
+       r="10.514005" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6371"
+       id="radialGradient14356"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.364191,-0.0839295,0.02901286,0.454155,-243.14116,-58.912932)"
+       cx="180.41057"
+       cy="-102.4826"
+       fx="180.41057"
+       fy="-102.4826"
+       r="46.433735" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6689"
+       id="radialGradient14358"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4417133,0.0992707,-0.1595648,0.7465321,92.498922,-58.786917)"
+       cx="199.44173"
+       cy="-118.11351"
+       fx="199.44173"
+       fy="-118.11351"
+       r="42.844311" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6474"
+       id="linearGradient14360"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.5,-1.25)"
+       x1="227.5"
+       y1="-126.74134"
+       x2="231.25"
+       y2="-126.74134" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6474"
+       id="linearGradient14362"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(8.2823329,-1.0244298)"
+       x1="227.5"
+       y1="-126.74134"
+       x2="231.25"
+       y2="-126.74134" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6745"
+       id="radialGradient14364"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.9324324,0,-39.39527)"
+       cx="112.25"
+       cy="39.145103"
+       fx="112.25"
+       fy="39.145103"
+       r="9.25" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6745"
+       id="radialGradient14366"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7409988,0.1665323,-0.3407516,1.5162021,138.52219,-253.64648)"
+       cx="112.25"
+       cy="39.145103"
+       fx="112.25"
+       fy="39.145103"
+       r="9.25" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6441"
+       id="radialGradient14368"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7070564,0.4436046,-0.07336821,0.3053749,-172.07418,-223.71208)"
+       cx="225.18816"
+       cy="-202.85997"
+       fx="225.18816"
+       fy="-202.85997"
+       r="23.65896" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6415"
+       id="radialGradient14370"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7409988,0.1665323,-0.5799398,2.5804888,162.69581,-331.76777)"
+       cx="70.625"
+       cy="60.43581"
+       fx="70.625"
+       fy="60.43581"
+       r="5.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6358"
+       id="radialGradient14437"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3058823,0.02352941,-0.01765849,0.9800465,-67.740896,0.6035973)"
+       cx="211.5"
+       cy="-172.53897"
+       fx="211.5"
+       fy="-172.53897"
+       r="42.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6371"
+       id="radialGradient14451"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.364191,-0.0839295,0.02901286,0.454155,-243.14116,-58.912932)"
+       cx="180.41057"
+       cy="-102.4826"
+       fx="180.41057"
+       fy="-102.4826"
+       r="46.433735" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6689"
+       id="radialGradient14453"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4417133,0.0992707,-0.1595648,0.7465321,92.498922,-58.786917)"
+       cx="199.44173"
+       cy="-118.11351"
+       fx="199.44173"
+       fy="-118.11351"
+       r="42.844311" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6415"
+       id="radialGradient14465"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7409988,0.1665323,-0.5799398,2.5804888,162.69581,-331.76777)"
+       cx="70.625"
+       cy="60.43581"
+       fx="70.625"
+       fy="60.43581"
+       r="5.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6441"
+       id="radialGradient14469"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.3210347,0.07274628,0.00608687,0.39049884,739.54522,389.82101)"
+       cx="225.18816"
+       cy="-202.85997"
+       fx="225.18816"
+       fy="-202.85997"
+       r="23.65896" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6745"
+       id="radialGradient14473"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99999995,-1.080681e-8,-9.401742e-8,1.9324323,349.18164,268.81468)"
+       cx="112.25"
+       cy="39.145103"
+       fx="112.25"
+       fy="39.145103"
+       r="9.25" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6745"
+       id="radialGradient14476"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.99999995,-1.080681e-8,-9.4915746e-8,1.9324323,341.68163,268.81468)"
+       cx="112.25"
+       cy="39.145103"
+       fx="112.25"
+       fy="39.145103"
+       r="9.25" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6474"
+       id="linearGradient14479"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.2846447,-0.2726646,-0.2887114,1.2132429,443.55872,610.81839)"
+       x1="227.5"
+       y1="-126.74134"
+       x2="231.25"
+       y2="-126.74134" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6474"
+       id="linearGradient14482"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.2846447,-0.2726646,-0.2887114,1.2132429,453.62138,612.66668)"
+       x1="227.5"
+       y1="-126.74134"
+       x2="231.25"
+       y2="-126.74134" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6349-8"
+       id="radialGradient14488"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.2846447,-0.2726646,-0.38906575,1.6349589,437.0411,685.17703)"
+       cx="194.55148"
+       cy="-168.02176"
+       fx="194.55148"
+       fy="-168.02176"
+       r="10.514005" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6383"
+       id="radialGradient14492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.4403592,-0.30571485,-0.18850392,0.79214412,507.70633,544.95095)"
+       cx="226.67188"
+       cy="-153.96692"
+       fx="226.67188"
+       fy="-153.96692"
+       r="11.671875" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6735"
+       id="radialGradient14496"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.8169665,-0.41545334,-0.8909024,3.3132843,469.05091,953.98039)"
+       cx="195.68195"
+       cy="-149.60544"
+       fx="195.68195"
+       fy="-149.60544"
+       r="8.5016947" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6757"
+       id="radialGradient14499"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.9371479,-0.68328737,-0.98339696,3.8029161,681.41289,1090.8315)"
+       cx="201.52219"
+       cy="-150.49968"
+       fx="201.52219"
+       fy="-150.49968"
+       r="17.65089" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6358"
+       id="radialGradient14502"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.684388,-0.32752099,-0.26026571,1.1938493,680.50153,633.52242)"
+       cx="211.5"
+       cy="-172.53897"
+       fx="211.5"
+       fy="-172.53897"
+       r="42.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6391"
+       id="linearGradient14506"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.2204937,-0.24517132,-0.57415609,1.0909095,402.42138,567.91912)"
+       x1="162.0209"
+       y1="-141.84306"
+       x2="228.07239"
+       y2="-112.76989" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6358"
+       id="radialGradient14517"
+       cx="145.66061"
+       cy="135.25136"
+       fx="143.9269"
+       fy="107.87556"
+       r="93.979218"
+       gradientTransform="matrix(1.3046625,0.24901908,-0.19221053,1.0070308,-15.829753,-36.419162)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6757"
+       id="radialGradient14521"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.9371479,-0.68328737,-0.98339696,3.8029161,741.41289,1070.8315)"
+       cx="201.52219"
+       cy="-150.49968"
+       fx="201.52219"
+       fy="-150.49968"
+       r="17.65089" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6735"
+       id="radialGradient5439"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.1363448,-1.3762794,-1.2454984,3.2157229,960.71525,910.14242)"
+       cx="196.44872"
+       cy="-151.91595"
+       fx="196.44872"
+       fy="-151.91595"
+       r="8.5016947" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6735"
+       id="radialGradient5450"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.1363448,-1.3762794,-1.2454984,3.2157229,1019.0966,903.42491)"
+       cx="196.35606"
+       cy="-150.96611"
+       fx="196.35606"
+       fy="-150.96611"
+       r="8.5016947" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6745"
+       id="radialGradient5468"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.0257663,-3.6029321e-8,-2.8447476e-7,6.4426248,536.89679,-145.17956)"
+       cx="112.25"
+       cy="39.145103"
+       fx="112.25"
+       fy="39.145103"
+       r="9.25" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6745"
+       id="radialGradient5472"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.6189689,-0.16929915,-0.39464806,6.1049956,454.32348,-102.8318)"
+       cx="112.25"
+       cy="39.145103"
+       fx="112.25"
+       fy="39.145103"
+       r="9.25" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6757"
+       id="linearGradient5498"
+       x1="163.89485"
+       y1="82.26004"
+       x2="208.11172"
+       y2="185.85118"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6757"
+       id="linearGradient5500"
+       x1="129.75412"
+       y1="83.446373"
+       x2="190.56531"
+       y2="84.507034"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6757"
+       id="linearGradient5502"
+       x1="109.89773"
+       y1="95.666252"
+       x2="67.631767"
+       y2="201.73227"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6757"
+       id="linearGradient5504"
+       x1="112.62962"
+       y1="99.346718"
+       x2="136.82567"
+       y2="162.27922"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6383"
+       id="radialGradient5508"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0434202,-0.53150013,-0.26742823,1.3771811,546.19997,442.52249)"
+       cx="226.67188"
+       cy="-153.96692"
+       fx="226.67188"
+       fy="-153.96692"
+       r="11.671875" />
+    <filter
+       inkscape:collect="always"
+       id="filter5531">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.2196638"
+         id="feGaussianBlur5533" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6383"
+       id="radialGradient5537"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0434202,-0.53150013,-0.26742823,1.3771811,599.94009,431.56233)"
+       cx="226.67188"
+       cy="-153.96692"
+       fx="226.67188"
+       fy="-153.96692"
+       r="11.671875" />
+    <filter
+       inkscape:collect="always"
+       id="filter5576">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.5408815"
+         id="feGaussianBlur5578" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5582">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5584"
+         d="m 134.78125,65.53125 c -12.4595,-0.04552 -23.54116,3.516311 -33.21875,9.59375 -0.007,0.0047 -0.0238,-0.0047 -0.0312,0 -13.697841,4.6271 -23.482877,12.212186 -30.8125,22.53125 -12.983809,18.27935 -23.557494,60.03358 -22.40625,85.1875 28.303398,44.55783 163.81724,43.74576 187.875,3.125 -10.47295,-36.77579 -7.13398,-67.94114 -23.7813,-89.21875 -8.90024,-11.375757 -21.77064,-18.931807 -35.8125,-23.09375 -0.0724,-0.02147 -0.14625,-0.04121 -0.21875,-0.0625 -6.47957,-2.470774 -22.68841,-8 -39.1875,-8 -0.80529,-0.03223 -1.61208,-0.0596 -2.40625,-0.0625 z m 29.3125,5.34375 c 0.44849,0.06863 0.89602,0.143789 1.34375,0.21875 -0.44964,-0.07493 -0.89333,-0.150215 -1.34375,-0.21875 z m -45.40625,0.3125 c -0.96659,0.136121 -1.90642,0.281449 -2.84375,0.4375 0.93942,-0.156725 1.87493,-0.300819 2.84375,-0.4375 z"
+         style="fill:#a40000;fill-opacity:1;stroke:none" />
+    </clipPath>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6415"
+       id="radialGradient5588"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7409988,0.1665323,-0.5799398,2.5804888,162.69581,-331.76777)"
+       cx="70.625"
+       cy="60.43581"
+       fx="70.625"
+       fy="60.43581"
+       r="5.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6349-8"
+       id="radialGradient5592"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.296581,0.04854441,0.65792091,4.6567361,485.37446,904.7596)"
+       cx="194.55148"
+       cy="-168.02176"
+       fx="194.55148"
+       fy="-168.02176"
+       r="10.514005" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6349-8"
+       id="radialGradient5596"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.558501,0.13248114,1.0967481,5.1492347,667.29092,965.69999)"
+       cx="194.55148"
+       cy="-168.02176"
+       fx="194.55148"
+       fy="-168.02176"
+       r="10.514005" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6474"
+       id="linearGradient5600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.7447879,-0.38299996,-0.31793238,1.2066937,515.40386,308.18711)"
+       x1="227.5"
+       y1="-126.74134"
+       x2="231.25"
+       y2="-126.74134" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6474"
+       id="linearGradient5604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.0701041,-0.01735592,-0.07408665,1.2462359,574.05206,233.49649)"
+       x1="227.5"
+       y1="-126.74134"
+       x2="231.25"
+       y2="-126.74134" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5623"
+       id="radialGradient5629"
+       cx="110.62334"
+       cy="79.932693"
+       fx="110.62334"
+       fy="79.932693"
+       r="81.577972"
+       gradientTransform="matrix(-0.58592607,0.97377054,-1.0186737,-0.61294465,256.86576,29.216301)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6371"
+       id="radialGradient5639"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.364191,-0.0839295,0.02901286,0.454155,-243.14116,-58.912932)"
+       cx="180.41057"
+       cy="-102.4826"
+       fx="180.41057"
+       fy="-102.4826"
+       r="46.433735" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5655"
+       id="radialGradient5661"
+       cx="201.96198"
+       cy="227.23029"
+       fx="201.96198"
+       fy="227.23029"
+       r="94.479218"
+       gradientTransform="matrix(0.76798801,-0.31808094,0.29894407,0.72178314,-21.071551,110.33848)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6474"
+       id="linearGradient5665"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.3664907,-0.60795991,-0.75658603,2.7051661,726.62427,665.95994)"
+       x1="227.5"
+       y1="-126.74134"
+       x2="231.25"
+       y2="-126.74134" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6474"
+       id="linearGradient5669"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.8760451,-0.57383621,-0.64636315,2.55333,645.41259,647.24954)"
+       x1="227.5"
+       y1="-126.74134"
+       x2="231.25"
+       y2="-126.74134" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6391"
+       id="radialGradient5720"
+       cx="170.17645"
+       cy="223.42529"
+       fx="170.17645"
+       fy="223.42529"
+       r="106.61834"
+       gradientTransform="matrix(1,0,0,0.30000319,0,144.84775)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5724"
+       id="radialGradient5738"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32219361,0,139.51544)"
+       cx="161.50815"
+       cy="304.25235"
+       fx="161.50815"
+       fy="304.25235"
+       r="106.59425" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6358"
+       id="radialGradient5754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3046625,0.24901908,-0.19221053,1.0070308,-15.829753,-36.419162)"
+       cx="145.66061"
+       cy="135.25136"
+       fx="143.9269"
+       fy="107.87556"
+       r="93.979218" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5742"
+       id="radialGradient5774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3844902,-0.20855016,0.06498177,0.43139087,-78.968394,178.11578)"
+       cx="94.043854"
+       cy="260.62152"
+       fx="94.043854"
+       fy="260.62152"
+       r="106.59425" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5742"
+       id="radialGradient5776"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3844902,-0.20855016,0.06498177,0.43139087,-78.968394,178.11578)"
+       cx="212.00848"
+       cy="288.14557"
+       fx="212.00848"
+       fy="288.14557"
+       r="106.59425" />
+    <filter
+       inkscape:collect="always"
+       id="filter5778">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.7619388"
+         id="feGaussianBlur5780" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6474"
+       id="linearGradient5784"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.79606,0.1563926,-0.1821094,1.8417489,-200.39675,376.2858)"
+       x1="227.5"
+       y1="-126.74134"
+       x2="231.25"
+       y2="-126.74134" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5623"
+       id="radialGradient5788"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.1030053,0.05104207,-0.01294422,-0.27972062,245.25589,81.239902)"
+       cx="80.688774"
+       cy="56.483025"
+       fx="80.688774"
+       fy="56.483025"
+       r="81.577972" />
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Máirín Duffy Strode</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="" />
+        <dc:title>Foreman Icon</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>foreman</rdf:li>
+            <rdf:li>puppet</rdf:li>
+            <rdf:li>management</rdf:li>
+            <rdf:li>systems</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:date>25 May 2011</dc:date>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:language />
+        <dc:coverage />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Lapo Calamandrei (used some parts from Gimp devel icon)</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="foreman"
+     transform="translate(-20.052918,-61.124418)">
+    <g
+       inkscape:groupmode="layer"
+       id="layer11"
+       inkscape:label="baseplate" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer9"
+       inkscape:label="small sizes" />
+    <g
+       inkscape:groupmode="layer"
+       id="layer3"
+       inkscape:label="hires">
+      <path
+         sodipodi:nodetypes="caccc"
+         inkscape:connector-curvature="0"
+         id="path5756"
+         d="m 47.517742,190.58865 c -24.661818,7.34836 30.107488,42.0632 53.215038,48.76539 47.10837,13.66346 77.72807,17.46747 144.84541,-25.9385 27.10145,-23.94119 -19.54007,-25.35005 -81.13247,-21.37581 C 60.312854,186.46791 52.668054,170.94584 47.517742,190.58865 Z"
+         style="opacity:0.53571424;fill:#2e3436;fill-opacity:1;stroke:none;filter:url(#filter5778)" />
+      <path
+         style="fill:url(#radialGradient5720);fill-opacity:1;stroke:none"
+         d="m 47.517742,184.58865 c -24.661818,7.34836 30.107488,42.0632 53.215038,48.76539 47.10837,13.66346 77.72807,17.46747 144.84541,-25.9385 27.10145,-23.94119 -19.54007,-25.35005 -81.13247,-21.37581 C 60.312854,180.46791 52.668054,164.94584 47.517742,184.58865 Z"
+         id="path5611"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="caccc" />
+      <path
+         style="fill:none;stroke:url(#radialGradient5661);stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+         d="M 144.875,71.136644 C 105.80516,70.294539 84.168562,80.018877 70.724838,98.945724 57.741029,117.22508 47.1669,158.99551 48.318144,184.14943 76.621542,228.70726 212.1329,227.8944 236.19066,187.27364 225.71776,150.49785 229.06123,119.32561 212.41391,98.047994 196.97739,78.317961 169.6041,70.016595 144.875,71.136644 Z"
+         id="path9655"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccsc" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5784);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 233.6379,168.41111 c 3.40176,-0.0521 3.70367,17.50535 3.70367,17.50535 0,0 -2.75413,2.66269 -6.15589,2.71478 -3.40176,0.0521 -7.45113,-2.50643 -7.45113,-2.50643 0,0 6.50162,-17.66164 9.90337,-17.71373 z"
+         id="path5782"
+         sodipodi:nodetypes="ccscs"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="csccsc"
+         inkscape:connector-curvature="0"
+         id="path5653"
+         d="M 144.875,69.84375 C 105.80516,69.001645 84.168562,78.725983 70.724838,97.65283 57.741029,115.93218 47.1669,157.70261 48.318144,182.85653 76.621542,227.41436 212.1329,226.6015 236.19066,185.98074 225.71776,149.20495 229.06123,118.03271 212.41391,96.7551 196.97739,77.025067 169.6041,68.723701 144.875,69.84375 Z"
+         style="opacity:1;fill:url(#radialGradient14517);fill-opacity:1;stroke:none" />
+      <path
+         style="opacity:0.3;fill:url(#radialGradient5754);fill-opacity:1;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5576)"
+         d="m 134.78125,65.53125 c -12.4595,-0.04552 -23.54116,3.516311 -33.21875,9.59375 -0.007,0.0047 -0.0238,-0.0047 -0.0312,0 -13.697841,4.6271 -23.482877,12.212186 -30.8125,22.53125 -12.983809,18.27935 -23.557494,60.03358 -22.40625,85.1875 28.303398,44.55783 163.81724,43.74576 187.875,3.125 -10.47295,-36.77579 -7.13398,-67.94114 -23.7813,-89.21875 -8.90024,-11.375757 -21.77064,-18.931807 -35.8125,-23.09375 -0.0724,-0.02147 -0.14625,-0.04121 -0.21875,-0.0625 -6.47957,-2.470774 -22.68841,-8 -39.1875,-8 -0.80529,-0.03223 -1.61208,-0.0596 -2.40625,-0.0625 z m 29.3125,5.34375 c 0.44849,0.06863 0.89602,0.143789 1.34375,0.21875 -0.44964,-0.07493 -0.89333,-0.150215 -1.34375,-0.21875 z m -45.40625,0.3125 c -0.96659,0.136121 -1.90642,0.281449 -2.84375,0.4375 0.93942,-0.156725 1.87493,-0.300819 2.84375,-0.4375 z"
+         id="path5547"
+         inkscape:connector-curvature="0"
+         clip-path="url(#clipPath5582)" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5437"
+         d="m 136.24045,150.51155 -0.49212,11.88839 23.66398,-1.7415 -1.0754,-11.53211 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient5439);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient5450);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 194.79859,144.68832 -0.6689,10.99411 19.42134,-1.7415 1.9298,-10.64823 z"
+         id="path5448"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5604);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 111.34878,64.720314 c -3.86755,-0.266211 -6.89562,11.475613 -6.89562,11.475613 0,0 2.73063,1.971101 6.59817,2.237315 3.86757,0.266211 8.87204,-1.172455 8.87204,-1.172455 0,0 -4.70703,-12.274259 -8.57459,-12.540463 z"
+         id="path5602"
+         sodipodi:nodetypes="ccscs"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscs"
+         id="path5598"
+         d="m 159.20259,61.182135 c -3.21186,-0.944378 -8.17524,10.012915 -8.17524,10.012915 0,0 1.90231,2.412077 5.11417,3.356457 3.21188,0.944382 7.73328,0.421076 7.73328,0.421076 0,0 -1.46034,-12.846064 -4.67221,-13.790438 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5600);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+      <path
+         sodipodi:nodetypes="cccccccccsccc"
+         inkscape:connector-curvature="0"
+         id="path5786"
+         d="m 137.17872,150.68956 22.27386,-1.41422 c -2.70259,-25.28221 -14.31112,-43.94051 -28.63783,-65.65001 6.56459,-1.48436 19.84045,-5.546179 29.92031,0 16.29639,20.28079 26.00565,37.46887 32.88047,61.51829 l 22.62742,-1.41422 c -12.62313,-29.59418 -16.41684,-50.35224 -36.76956,-68.94291 0,0 -21.08147,-9.192388 -42.29467,-9.192388 -51.538441,-2.062689 -80.338816,56.485948 -83.438605,105.712468 -0.989681,27.57981 -2.297271,25.30167 8.131728,31.8198 8.485282,5.3033 7.424621,-1.76776 7.424621,-1.76776 -4.264533,-53.48745 27.030509,-95.33946 41.012186,-109.248 12.6241,17.48846 20.83746,39.2072 26.87007,58.57895 z"
+         style="fill:url(#radialGradient5788);fill-opacity:1;stroke:none" />
+      <path
+         style="fill:url(#radialGradient5629);fill-opacity:1;stroke:none"
+         d="m 137.17872,150.68956 22.27386,-1.41422 c -2.70259,-25.28221 -14.31112,-43.94051 -28.63783,-65.65001 6.56459,-1.48436 19.84045,-5.546179 29.92031,0 16.29639,20.28079 26.00565,37.46887 32.88047,61.51829 l 22.62742,-1.41422 c -12.62313,-29.59418 -16.41684,-50.35224 -36.76956,-68.94291 0,0 -21.08147,-9.192388 -42.29467,-9.192388 -51.538441,-2.062689 -80.338816,56.485948 -83.438605,105.712468 -0.989681,27.57981 -2.297271,25.30167 8.131728,31.8198 8.485282,5.3033 7.424621,-1.76776 7.424621,-1.76776 -4.264533,-53.48745 27.030509,-95.33946 41.012186,-109.248 12.6241,17.48846 20.83746,39.2072 26.87007,58.57895 z"
+         id="path5452"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccsccc" />
+      <path
+         style="fill:url(#linearGradient5502);fill-opacity:1;stroke:none"
+         d="m 110.41173,92.275037 -0.0567,7.674763 c -35.011679,25.58564 -40.51385,78.1211 -40.407339,88.91025 0.624394,-26.09653 3.463291,-65.23353 40.464039,-96.585013 z"
+         id="path4622"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path5441"
+         d="m 159.29866,85.340619 c 19.33658,20.359071 31.31211,57.781931 34.49057,70.948611 l 0.88747,-5.66973 C 190.96806,124.94919 172.85403,92.055389 160.02263,81.062843 Z"
+         style="fill:url(#linearGradient5498);fill-opacity:1;stroke:none" />
+      <path
+         style="fill:url(#linearGradient5504);fill-opacity:1;stroke:none"
+         d="m 110.15474,99.8259 c 1.70533,1.32903 16.03807,29.22723 25.42991,63.18084 l 1.24102,-8.13419 C 122.73335,111.54627 118.87627,104.76641 110.1716,92.25523 Z"
+         id="path4624"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:url(#linearGradient5500);fill-opacity:1;stroke:none"
+         d="m 129.75412,83.289593 c 9.8346,-4.576555 20.25028,-5.01323 30.40559,-2.474875 0,1.454654 0,2.909307 0,4.363961 -20.60168,-1.638038 -26.74621,3.526107 -27.22734,2.232783 -0.70586,-1.020403 -2.47239,-3.101466 -3.17825,-4.121869 z"
+         id="rect5445"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         id="path5466"
+         d="M 224.10814,186.61565 C 217.41288,132.87914 200.44248,86.428031 168.1315,67.42704 c 35.93853,24.502774 47.31547,71.23151 55.97664,119.18861 z"
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.86746988;fill:url(#radialGradient5468);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.86746988;fill:url(#radialGradient5472);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         d="m 163.26316,194.07421 c -2.50345,-51.29504 -14.34688,-96.26139 -41.1499,-116.074503 29.60586,25.229543 36.59083,70.146003 41.1499,116.074503 z"
+         id="path5470"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path5506"
+         d="m 125.73895,90.106929 c 15.79156,4.107426 27.19343,14.725041 25.45062,23.700041 -1.50722,7.76179 -12.38002,11.77575 -25.49927,10.05964 -4.80122,-17.84892 -12.37206,-29.280241 -19.84822,-34.58723 5.56801,-1.267506 12.5577,-1.081394 19.89687,0.827549 z"
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.70982139;fill:url(#radialGradient5508);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;filter:url(#filter5531);enable-background:accumulate" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.70982139;fill:url(#radialGradient5537);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;filter:url(#filter5531);enable-background:accumulate"
+         d="m 179.47907,79.146774 c 15.79156,4.107426 27.19343,14.725041 25.45062,23.700036 -1.50722,7.76179 -12.38002,11.77575 -25.49927,10.05964 -4.80122,-17.848915 -12.37206,-29.280236 -19.84822,-34.587225 5.56801,-1.267506 12.5577,-1.081394 19.89687,0.827549 z"
+         id="path5535"
+         inkscape:connector-curvature="0"
+         transform="matrix(0.98686145,-0.16156878,0.16156878,0.98686145,-13.018753,30.714568)" />
+      <path
+         transform="matrix(-3.9559661,-0.51568857,-0.8890649,2.2945975,783.57602,590.80594)"
+         inkscape:connector-curvature="0"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient5588);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;filter:url(#filter6435);enable-background:accumulate"
+         d="m 188.786,-178.55812 c -7.5253,6.36451 -11.91096,21.1212 -16.62389,35.00309 5.399,-12.85475 10.70671,-26.47104 16.62389,-35.00309 z"
+         id="path5586"
+         sodipodi:nodetypes="ccc" />
+      <path
+         sodipodi:nodetypes="cccc"
+         id="path5590"
+         d="M 143.12732,180.22151 C 132.03919,130.42403 119.6804,94.374766 102.02804,83.320425 c 7.30898,4.095835 21.29349,7.504665 38.79202,85.022905 l 2.30726,11.87818 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient5592);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient5596);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 207.72201,179.03705 c -16.60936,-54.81907 -33.85074,-94.241665 -55.8346,-105.492323 9.071,4.122115 26.13746,7.075114 52.27938,92.395943 l 3.55522,13.09638 z"
+         id="path5594"
+         sodipodi:nodetypes="cccc" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5665);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         d="m 63.983498,171.17508 c -6.170296,-1.64713 -18.06707,18.76119 -18.06707,18.76119 1.138294,3.43601 9.212664,5.63224 13.740156,4.61269 0,0 10.497236,-21.72674 4.326914,-23.37388 z"
+         id="path5663"
+         sodipodi:nodetypes="cccs" />
+      <path
+         sodipodi:nodetypes="caccc"
+         inkscape:connector-curvature="0"
+         id="path5722"
+         d="m 47.517742,182.58865 c -24.661818,7.34836 30.107488,42.0632 53.215038,48.76539 47.10837,13.66346 77.72807,17.46747 144.84541,-25.9385 27.10145,-23.94119 -19.54007,-25.35005 -81.13247,-21.37581 C 60.312854,178.46791 52.668054,162.94584 47.517742,182.58865 Z"
+         style="fill:none;stroke:url(#radialGradient5738);stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccscs"
+         id="path5667"
+         d="m 74.436829,178.59354 c -5.271402,-1.55469 -14.607007,21.89679 -14.607007,21.89679 0,0 2.944631,4.77859 8.21601,6.33328 5.271402,1.55471 12.869552,-0.11444 12.869552,-0.11444 0,0 -1.207176,-26.56089 -6.478555,-28.11557 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5669);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+      <g
+         id="g5770"
+         transform="translate(0,-40)">
+        <path
+           style="fill:none;stroke:url(#radialGradient5774);stroke-opacity:1"
+           d="m 47.517742,224.58865 c -24.661818,7.34836 30.107488,42.0632 53.215038,48.76539 47.10837,13.66346 77.72807,17.46747 144.84541,-25.9385 13.55072,-11.9706 8.66571,-18.30811 -7.30604,-21.15619"
+           id="path5740"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cacc" />
+        <path
+           sodipodi:nodetypes="cacc"
+           inkscape:connector-curvature="0"
+           id="path5750"
+           d="m 47.517742,224.58865 c -24.661818,7.34836 30.107488,42.0632 53.215038,48.76539 47.10837,13.66346 77.72807,17.46747 144.84541,-25.9385 13.55072,-11.9706 8.66571,-18.30811 -7.30604,-21.15619"
+           style="fill:none;stroke:url(#radialGradient5776);stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add official Foreman SVG logo as favicon.svg to eliminate browser console 404 errors
- Downloaded from official Foreman graphics repository
- Resolves missing favicon reference in index.html

## Test plan
- [x] Verify favicon.svg file exists at `/packages/user-portal/public/favicon.svg`
- [x] Confirm HTML references correct path: `/favicon.svg`
- [x] Test that browser console no longer shows 404 errors for favicon

🤖 Generated with [Claude Code](https://claude.ai/code)