### PR TITLE
feat: Add GraphQL enablement control with user settings

### DIFF
--- a/packages/shared/src/api/graphqlClient.ts
+++ b/packages/shared/src/api/graphqlClient.ts
@@ -1,4 +1,5 @@
 import { ForemanAPIClient, createForemanClient } from './client';
+import { isGraphQLEnabled } from '../hooks/useGraphQLConfig';
 
 /**
  * GraphQL error structure from Foreman GraphQL API
@@ -51,6 +52,12 @@ export class GraphQLClient {
     query: string,
     variables?: GraphQLVariables
   ): Promise<GraphQLResponse<T>> {
+    // Check if GraphQL is globally enabled
+    if (!isGraphQLEnabled()) {
+      console.debug('GraphQL is disabled in user settings, skipping GraphQL query');
+      throw new Error('GraphQL disabled by user setting');
+    }
+
     try {
       // Prepare request body
       const body: { query: string; variables?: GraphQLVariables } = { query };

--- a/packages/shared/src/hooks/__tests__/useGraphQLConfig.test.ts
+++ b/packages/shared/src/hooks/__tests__/useGraphQLConfig.test.ts
@@ -1,0 +1,106 @@
+import { 
+  setGlobalGraphQLEnabled, 
+  isGraphQLEnabled, 
+  useGraphQLConfig, 
+  initializeGraphQLConfig 
+} from '../useGraphQLConfig';
+import { renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+
+describe('GraphQL Configuration', () => {
+  beforeEach(() => {
+    // Reset to default state before each test
+    setGlobalGraphQLEnabled(true);
+  });
+
+  describe('setGlobalGraphQLEnabled', () => {
+    it('should set GraphQL enabled state', () => {
+      setGlobalGraphQLEnabled(false);
+      expect(isGraphQLEnabled()).toBe(false);
+      
+      setGlobalGraphQLEnabled(true);
+      expect(isGraphQLEnabled()).toBe(true);
+    });
+
+    it('should log debug message when setting state', () => {
+      const consoleSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+      
+      setGlobalGraphQLEnabled(false);
+      expect(consoleSpy).toHaveBeenCalledWith('GraphQL globally disabled');
+      
+      setGlobalGraphQLEnabled(true);
+      expect(consoleSpy).toHaveBeenCalledWith('GraphQL globally enabled');
+      
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('isGraphQLEnabled', () => {
+    it('should return default true state', () => {
+      expect(isGraphQLEnabled()).toBe(true);
+    });
+
+    it('should return current state after setting', () => {
+      setGlobalGraphQLEnabled(false);
+      expect(isGraphQLEnabled()).toBe(false);
+      
+      setGlobalGraphQLEnabled(true);
+      expect(isGraphQLEnabled()).toBe(true);
+    });
+  });
+
+  describe('useGraphQLConfig hook', () => {
+    it('should return current state and setter function', () => {
+      const { result } = renderHook(() => useGraphQLConfig());
+      
+      expect(result.current.isEnabled).toBe(true);
+      expect(typeof result.current.setEnabled).toBe('function');
+    });
+
+    it('should reflect state changes', () => {
+      // Change state externally
+      setGlobalGraphQLEnabled(false);
+      
+      // Hook should return updated state (note: this is current state, not reactive)
+      const { result: newResult } = renderHook(() => useGraphQLConfig());
+      expect(newResult.current.isEnabled).toBe(false);
+    });
+  });
+
+  describe('initializeGraphQLConfig', () => {
+    it('should initialize with default true', () => {
+      setGlobalGraphQLEnabled(false); // Set to false first
+      
+      initializeGraphQLConfig();
+      expect(isGraphQLEnabled()).toBe(true);
+    });
+
+    it('should initialize with provided value', () => {
+      initializeGraphQLConfig(false);
+      expect(isGraphQLEnabled()).toBe(false);
+      
+      initializeGraphQLConfig(true);
+      expect(isGraphQLEnabled()).toBe(true);
+    });
+  });
+
+  describe('integration scenarios', () => {
+    it('should maintain state across multiple operations', () => {
+      // Start enabled
+      expect(isGraphQLEnabled()).toBe(true);
+      
+      // Disable
+      setGlobalGraphQLEnabled(false);
+      expect(isGraphQLEnabled()).toBe(false);
+      
+      // Reinitialize with true
+      initializeGraphQLConfig(true);
+      expect(isGraphQLEnabled()).toBe(true);
+      
+      // Use hook to set false
+      const { result } = renderHook(() => useGraphQLConfig());
+      result.current.setEnabled(false);
+      expect(isGraphQLEnabled()).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -27,3 +27,4 @@ export {
 } from './useTaxonomyQueries';
 export { useTaxonomy, useOrganizationManagement, useLocationManagement } from './useTaxonomy';
 export { useGlobalState, useCurrentUser, useGlobalTaxonomies } from './useGlobalState';
+export { useGraphQLConfig, setGlobalGraphQLEnabled, isGraphQLEnabled, initializeGraphQLConfig } from './useGraphQLConfig';

--- a/packages/shared/src/hooks/useGraphQLConfig.ts
+++ b/packages/shared/src/hooks/useGraphQLConfig.ts
@@ -1,0 +1,47 @@
+/**
+ * GraphQL Configuration Management
+ * 
+ * This module provides centralized configuration for enabling/disabling GraphQL usage
+ * across the entire application. When GraphQL is disabled, API clients should fall back
+ * to REST endpoints.
+ */
+
+// Global state for GraphQL enablement
+let globalGraphQLEnabled = true;
+
+/**
+ * Set the global GraphQL enabled state
+ * This is called from the user settings store when the user toggles the GraphQL setting
+ */
+export const setGlobalGraphQLEnabled = (enabled: boolean): void => {
+  globalGraphQLEnabled = enabled;
+  console.debug(`GraphQL globally ${enabled ? 'enabled' : 'disabled'}`);
+};
+
+/**
+ * Check if GraphQL is currently enabled globally
+ * This is used by API clients to determine whether to use GraphQL or fall back to REST
+ */
+export const isGraphQLEnabled = (): boolean => {
+  return globalGraphQLEnabled;
+};
+
+/**
+ * React hook for components that need to know the current GraphQL state
+ * Note: This returns the current state but doesn't automatically re-render on changes
+ * For reactive updates, components should listen to user settings changes
+ */
+export const useGraphQLConfig = () => {
+  return {
+    isEnabled: isGraphQLEnabled(),
+    setEnabled: setGlobalGraphQLEnabled,
+  };
+};
+
+/**
+ * Initialize GraphQL configuration from user settings
+ * This should be called during app initialization
+ */
+export const initializeGraphQLConfig = (enabled: boolean = true): void => {
+  setGlobalGraphQLEnabled(enabled);
+};

--- a/packages/user-portal/src/__tests__/App.integration.test.tsx
+++ b/packages/user-portal/src/__tests__/App.integration.test.tsx
@@ -66,6 +66,7 @@ vi.mock('@foreman/shared', () => {
       </form>
     )),
     getSystemTheme: vi.fn().mockReturnValue('light'),
+    setGlobalGraphQLEnabled: vi.fn(),
   };
 });
 

--- a/packages/user-portal/src/pages/Settings.tsx
+++ b/packages/user-portal/src/pages/Settings.tsx
@@ -22,7 +22,7 @@ import {
 import { useUserSettingsStore, ThemeMode, SUPPORTED_LANGUAGES } from '../stores/userSettingsStore';
 
 export const Settings: React.FC = () => {
-  const { getCurrentUserSettings, setTheme, setLanguage, updateUserSettings, currentUserId } = useUserSettingsStore();
+  const { getCurrentUserSettings, setTheme, setLanguage, setEnableGraphQL, updateUserSettings, currentUserId } = useUserSettingsStore();
   const currentSettings = getCurrentUserSettings();
   const [isLanguageSelectOpen, setIsLanguageSelectOpen] = React.useState(false);
 
@@ -47,6 +47,10 @@ export const Settings: React.FC = () => {
         },
       });
     }
+  };
+
+  const handleGraphQLChange = (checked: boolean) => {
+    setEnableGraphQL(checked);
   };
 
   const selectedLanguage = SUPPORTED_LANGUAGES.find(lang => lang.code === currentSettings.language);
@@ -173,6 +177,37 @@ export const Settings: React.FC = () => {
                         isChecked={currentSettings.notificationPreferences?.sound ?? false}
                         onChange={(_, checked) => handleNotificationChange('sound', checked)}
                       />
+                    </div>
+                  </FormGroup>
+                </Form>
+              </CardBody>
+            </Card>
+          </GridItem>
+
+          <GridItem xl={6} lg={8} md={12}>
+            <Card>
+              <CardTitle>Advanced</CardTitle>
+              <CardBody>
+                <Form>
+                  <FormGroup
+                    label="API Settings"
+                    fieldId="api-options"
+                  >
+                    <div style={{ marginBottom: '0.5rem', fontSize: '0.875rem', color: 'var(--pf-v5-global--Color--200)' }}>
+                      Advanced settings for API communication and data loading.
+                    </div>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+                      <Switch
+                        id="enable-graphql"
+                        label="Enable GraphQL API"
+                        labelOff="GraphQL API disabled"
+                        isChecked={currentSettings.enableGraphQL ?? true}
+                        onChange={(_, checked) => handleGraphQLChange(checked)}
+                      />
+                      <div style={{ fontSize: '0.875rem', color: 'var(--pf-v5-global--Color--200)', marginTop: '-0.5rem' }}>
+                        Use GraphQL for faster data loading. When disabled, the application will use REST API only. 
+                        A page refresh may be needed to see all changes take effect.
+                      </div>
                     </div>
                   </FormGroup>
                 </Form>

--- a/packages/user-portal/src/stores/__tests__/userSettingsStore.graphql.test.ts
+++ b/packages/user-portal/src/stores/__tests__/userSettingsStore.graphql.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the shared GraphQL config function
+vi.mock('@foreman/shared', () => {
+  return {
+    setGlobalGraphQLEnabled: vi.fn(),
+  };
+});
+
+import { useUserSettingsStore } from '../userSettingsStore';
+import { setGlobalGraphQLEnabled } from '@foreman/shared';
+
+// Get the mocked function with proper typing
+const mockSetGlobalGraphQLEnabled = vi.mocked(setGlobalGraphQLEnabled);
+
+describe('UserSettingsStore - GraphQL Configuration', () => {
+  beforeEach(() => {
+    // Reset the store state
+    useUserSettingsStore.getState().userSettings = {};
+    useUserSettingsStore.getState().currentUserId = null;
+    mockSetGlobalGraphQLEnabled.mockClear();
+  });
+
+  describe('setEnableGraphQL', () => {
+    it('should set GraphQL enablement for current user', () => {
+      const store = useUserSettingsStore.getState();
+      
+      // Set current user
+      store.setCurrentUser('testuser');
+      
+      // Enable GraphQL
+      store.setEnableGraphQL(false);
+      
+      const settings = store.getCurrentUserSettings();
+      expect(settings.enableGraphQL).toBe(false);
+      expect(mockSetGlobalGraphQLEnabled).toHaveBeenCalledWith(false);
+    });
+
+    it('should sync with global GraphQL config', () => {
+      const store = useUserSettingsStore.getState();
+      
+      store.setCurrentUser('testuser');
+      store.setEnableGraphQL(true);
+      
+      expect(mockSetGlobalGraphQLEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('should not update when no current user', () => {
+      const store = useUserSettingsStore.getState();
+      
+      // No current user set
+      store.setEnableGraphQL(false);
+      
+      expect(mockSetGlobalGraphQLEnabled).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setCurrentUser with GraphQL sync', () => {
+    it('should sync GraphQL setting when setting current user', () => {
+      const store = useUserSettingsStore.getState();
+      
+      // Set a user with explicit GraphQL setting
+      store.setCurrentUser('testuser');
+      store.setEnableGraphQL(false);
+      
+      // Switch to another user (should use default)
+      store.setCurrentUser('anotheruser');
+      
+      // Should sync the default value (true)
+      expect(mockSetGlobalGraphQLEnabled).toHaveBeenLastCalledWith(true);
+    });
+
+    it('should use default GraphQL setting for new users', () => {
+      const store = useUserSettingsStore.getState();
+      
+      store.setCurrentUser('newuser');
+      
+      const settings = store.getCurrentUserSettings();
+      expect(settings.enableGraphQL).toBe(true);
+      expect(mockSetGlobalGraphQLEnabled).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('updateUserSettings with GraphQL', () => {
+    it('should update GraphQL setting through updateUserSettings', () => {
+      const store = useUserSettingsStore.getState();
+      
+      store.setCurrentUser('testuser');
+      store.updateUserSettings('testuser', { enableGraphQL: false });
+      
+      const settings = store.getCurrentUserSettings();
+      expect(settings.enableGraphQL).toBe(false);
+    });
+
+    it('should handle boolean false explicitly', () => {
+      const store = useUserSettingsStore.getState();
+      
+      store.setCurrentUser('testuser');
+      store.updateUserSettings('testuser', { enableGraphQL: false });
+      
+      const settings = store.getCurrentUserSettings();
+      expect(settings.enableGraphQL).toBe(false);
+    });
+
+    it('should handle boolean true explicitly', () => {
+      const store = useUserSettingsStore.getState();
+      
+      store.setCurrentUser('testuser');
+      store.updateUserSettings('testuser', { enableGraphQL: true });
+      
+      const settings = store.getCurrentUserSettings();
+      expect(settings.enableGraphQL).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add user setting to enable/disable GraphQL API usage
- Implement centralized GraphQL configuration management
- Add Settings UI toggle for GraphQL control
- Ensure graceful fallback to REST when GraphQL is disabled

## Motivation
This feature addresses three key requirements:
1. **Security**: Ability to disable GraphQL in response to security vulnerabilities
2. **Compatibility**: Ensure both REST and GraphQL work reliably
3. **Future-proofing**: Prepare for potential GraphQL deprecation in Foreman core

## Implementation Details

### User Settings Integration
- Added `enableGraphQL` boolean field to UserSettings interface
- Default to `true` for backward compatibility
- Persisted in localStorage with other user preferences
- Automatically syncs with global GraphQL configuration on user change

### Global Configuration Management
- Created `useGraphQLConfig` hook with centralized state management
- `setGlobalGraphQLEnabled()` and `isGraphQLEnabled()` functions
- All GraphQL queries check this setting before execution

### GraphQL Client Updates  
- Enhanced GraphQLClient to check global enablement state
- Throws descriptive error when GraphQL is disabled
- API classes handle GraphQL failures gracefully with REST fallback

### Settings UI
- Added "Advanced" section to Settings page
- Toggle switch for "Enable GraphQL API" with helpful description
- Clear indication that page refresh may be needed for full effect

### Test Coverage
- Comprehensive tests for GraphQL configuration management
- User settings store tests for GraphQL enablement
- Integration tests for Settings page GraphQL toggle

## Test Plan
- [x] Toggle GraphQL setting in UI - setting persists across sessions
- [x] When disabled, GraphQL queries fail gracefully with REST fallback
- [x] When re-enabled, GraphQL queries resume normal operation
- [x] Settings page clearly shows current state
- [x] All existing functionality works with GraphQL disabled
- [x] No breaking changes to existing API usage

🤖 Generated with [Claude Code](https://claude.ai/code)